### PR TITLE
Correct the spelling of CocoaPods in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ Requires ARC
 	3. Under Build on your Xcode Project file add 'libKLCircleViewController' & QuartzCore.framework under Link Binary With Libraries
 	4. Include #import <KLCircleViewController/KLCircleViewController.h> in any file you wish to use
 
-Install via Cocoapods by adding the following line to your podfile
+Install via CocoaPods by adding the following line to your podfile
 
 		pod 'KLCircleViewController'
 ## Usage ##


### PR DESCRIPTION
This pull requests corrects the spelling of **CocoaPods** 🤓
https://github.com/CocoaPods/shared_resources/tree/master/media

<blockquote class="twitter-tweet" data-lang="en"><p lang="en" dir="ltr">One day I’ll make a bot that looks through the READMEs of all Pods, looks to see if it uses “Cocoapods” and PRs “CocoaPods” :D</p>&mdash; Ørta (@orta) <a href="https://twitter.com/orta/status/697374357975388160">February 10, 2016</a></blockquote>

<script async src="//platform.twitter.com/widgets.js" charset="utf-8"></script>


Created with [`cocoapods-readme`](https://github.com/dkhamsing/cocoapods-readme).  
